### PR TITLE
Add a readme file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,63 @@
+Dionysus
+========
+
+Dionysus is a computational topology Python package for computing
+persistent homology. It is written in C++, with Python bindings.
+The second version (`previous version <http://mrzv.org/software/dionysus/>`_)
+ is re-written from scratch, which helps it accomplish a few goals:
+
+  * `Modified BSD license <https://github.com/mrzv/dionysus/blob/master/LICENSE.txt>`_ (because GPL causes too many problems in academic software).
+  * No dependency on Boost.Python; Dionysus 2 uses (and includes) `PyBind11 <https://github.com/pybind/pybind11>`_ instead, which greatly simplifies installation.
+  * Cleaner, more consistent internal design (for example, all algorithms support arbitrary fields).
+  * Some new algorithms, e.g., :ref:`omni-field` and :ref:`Wasserstein distance computation <diagram-distances>` from `Hera <https://bitbucket.org/grey_narn/hera>`_.
+  * A few :ref:`plotting` routines, based on `Matplotlib <https://matplotlib.org/>`_.
+  * Better integration with `NumPy <http://www.numpy.org/>`_.
+
+Features that haven't (yet) made it over from `Dionysus 1 <http://mrzv.org/software/dionysus>`_ include vineyards, alpha shapes, bottleneck distance.
+
+**Dependencies:**
+  * `Boost <http://www.boost.org/>`_, although Dionysus 2 doesn't link any of its libraries, so it's considerably easier to build the project.
+  * (Optional) `SciPy <https://www.scipy.org/>`_ for the LSQR routine used in :ref:`circular`.
+  * (Optional) `Maplotlib <https://matplotlib.org/>`_ for :ref:`plotting`.
+
+**Contact:**
+  * please use the `dionysus mailing list <https://groups.io/g/dionysus/>`_
+    for all questions and discussion related to the library;
+  * GitHub's `issue tracker <https://github.com/mrzv/dionysus/issues>`_
+    is a central location for bug reports and feature requests.
+
+Get, Build, Install
+-------------------
+
+The simplest way to install Dionysus as a Python package:
+
+.. parsed-literal::
+
+    pip install --verbose `git+https://github.com/mrzv/dionysus.git <https://github.com/mrzv/dionysus.git>`_
+
+Alternatively, you can clone and build everything by hand.
+To get Dionysus 2, either clone its `repository <https://github.com/mrzv/dionysus>`_:
+
+.. parsed-literal::
+
+    git clone `<https://github.com/mrzv/dionysus.git>`_
+
+or download it as a `Zip archive <https://github.com/mrzv/dionysus/archive/master.zip>`_.
+
+To build the project::
+
+    mkdir build
+    cd build
+    cmake ..
+    make
+
+To use the Python bindings, either launch Python from ``.../build/bindings/python`` or add this directory to your ``PYTHONPATH`` variable, by adding::
+
+    export PYTHONPATH=.../build/bindings/python:PYTHONPATH
+
+to your ``~/.bashrc`` or ``~/.zshrc``.
+
+Documentation
+-------------
+
+Documentation for Dionysus can be found `here <http://mrzv.org/software/dionysus2/>`_.


### PR DESCRIPTION
By adding a readme file, GitHub will automatically read it and add it as a "landing page" to your repository so new people know where to go. This file is derived from your `index.rst` file from the documentation.