### PR TITLE
Expose bottleneck matching edge

### DIFF
--- a/bindings/python/bottleneck-distance.cpp
+++ b/bindings/python/bottleneck-distance.cpp
@@ -4,18 +4,79 @@ namespace py = pybind11;
 #include "diagram.h"
 
 #include <hera/bottleneck.h>
+#include <cmath>
 
-double bottleneck_distance(const PyDiagram& dgm1, const PyDiagram& dgm2, double delta)
+py::object bottleneck_distance(const PyDiagram& dgm1,
+                               const PyDiagram& dgm2,
+                               double delta,
+                               bool compute_longest_edge)
 {
+    using Real = PyDiagram::Value;
+    double distance;
+
     if (delta == 0.0)
-        return hera::bottleneckDistExact(dgm1, dgm2);
+        distance = hera::bottleneckDistExact(dgm1, dgm2, 14);
     else
-        return hera::bottleneckDistApprox(dgm1, dgm2, delta);
+        distance = hera::bottleneckDistApprox(dgm1, dgm2, delta);
+
+    if (!compute_longest_edge)
+        return py::float_(distance);
+
+    if (distance == 0.0 || std::isinf(distance))
+        return py::make_tuple(distance, py::make_tuple(-1, -1));
+
+    hera::bt::DiagramPointSet<Real> all_a(dgm1);
+    hera::bt::DiagramPointSet<Real> all_b(dgm2);
+    const auto infinity_cost_edge = hera::bt::getInfinityCost(all_a, all_b, true);
+
+    hera::bt::DiagramPointSet<Real> finite_a;
+    hera::bt::DiagramPointSet<Real> finite_b;
+    for (const auto& point : all_a)
+        if (!point.is_infinity())
+            finite_a.insert(point);
+    for (const auto& point : all_b)
+        if (!point.is_infinity())
+            finite_b.insert(point);
+
+    hera::bt::MatchingEdge<Real> finite_edge;
+    if (delta == 0.0)
+        hera::bt::bottleneckDistExact(finite_a, finite_b, 14, finite_edge, true);
+    else
+        hera::bt::bottleneckDistApprox(
+            finite_a, finite_b, static_cast<Real>(delta), finite_edge, true);
+
+    const auto edge_cost = [](const auto& edge)
+    {
+        if (edge.first.is_diagonal() && edge.second.is_normal())
+            return edge.second.persistence_lp(hera::get_infinity());
+        if (edge.first.is_normal() && edge.second.is_diagonal())
+            return edge.first.persistence_lp(hera::get_infinity());
+        return hera::bt::dist_l_inf_slow(edge.first, edge.second);
+    };
+    const auto finite_edge_cost = edge_cost(finite_edge);
+    const auto& longest_edge = finite_edge_cost > infinity_cost_edge.cost
+                                   ? finite_edge
+                                   : infinity_cost_edge.edge;
+    const auto index = [](const auto& point)
+    {
+        return point.is_diagonal() ? -1 : point.user_tag;
+    };
+
+    return py::make_tuple(distance,
+                          py::make_tuple(index(longest_edge.first), index(longest_edge.second)));
 }
 
 void init_bottleneck_distance(py::module& m)
 {
     using namespace pybind11::literals;
-    m.def("bottleneck_distance",   &bottleneck_distance, "dgm1"_a, "dgm2"_a, py::arg("delta") = 0.01,
-          "compute bottleneck distance between two persistence diagrams");
+    m.def("bottleneck_distance",
+          &bottleneck_distance,
+          "dgm1"_a,
+          "dgm2"_a,
+          py::arg("delta") = 0.01,
+          py::arg("compute_longest_edge") = false,
+          "Compute bottleneck distance between two persistence diagrams.\n\n"
+          "When compute_longest_edge is true, return "
+          "(distance, (index_in_dgm1, index_in_dgm2)). A -1 index denotes "
+          "the diagonal; zero and infinite distances return (-1, -1).");
 }

--- a/doc/tutorial/basics.rst
+++ b/doc/tutorial/basics.rst
@@ -251,6 +251,20 @@ Diagram Distances
     >>> print("Bottleneck distance between 1-dimensional persistence diagrams:", bdist)
     Bottleneck distance between 1-dimensional persistence diagrams: 0.060736045241355896
 
+Pass ``compute_longest_edge=True`` to also return a pair of input point
+indices. For a finite, nonzero distance, with ``delta=0`` the edge realizes
+the exact distance. With a positive ``delta``, it is the longest edge in one
+of Hera's approximate matchings, while the returned distance is an upper
+bound and need not equal the edge length. An index of ``-1`` represents the
+diagonal. Zero and infinite distances return the sentinel pair ``(-1, -1)``.
+
+.. doctest::
+
+    >>> dgm1 = d.Diagram([(0, 10)])
+    >>> dgm2 = d.Diagram([(2, 12)])
+    >>> d.bottleneck_distance(dgm1, dgm2, delta=0, compute_longest_edge=True)
+    (2.0, (0, 0))
+
 .. _homologous-cycles:
 
 Homologous Cycles

--- a/tests/test_distances.py
+++ b/tests/test_distances.py
@@ -1,7 +1,80 @@
+import math
+
 import dionysus as d
 
-def test_distance():
-    dgm1 = d.Diagram([(1,2), (3,4), (1., float('inf'))])
-    dgm2 = d.Diagram([(0,2), (3,5), (2., float('inf'))])
-    dist = d.bottleneck_distance(dgm1,dgm2)
-    assert dist == 1
+
+def test_bottleneck_distance_returns_scalar_by_default():
+    dgm1 = d.Diagram([(1, 2), (3, 4), (1.0, float("inf"))])
+    dgm2 = d.Diagram([(0, 2), (3, 5), (2.0, float("inf"))])
+
+    distance = d.bottleneck_distance(dgm1, dgm2)
+
+    assert isinstance(distance, float)
+    assert distance == 1
+
+
+def test_bottleneck_distance_returns_longest_point_to_point_edge():
+    dgm1 = d.Diagram([(0, 10)])
+    dgm2 = d.Diagram([(2, 12)])
+
+    distance, edge = d.bottleneck_distance(
+        dgm1, dgm2, delta=0, compute_longest_edge=True
+    )
+
+    assert distance == 2
+    assert edge == (0, 0)
+
+
+def test_bottleneck_distance_normalizes_diagonal_edge_indices():
+    point = d.Diagram([(0, 4)])
+    empty = d.Diagram([])
+
+    assert d.bottleneck_distance(
+        point, empty, delta=0, compute_longest_edge=True
+    ) == (2, (0, -1))
+    assert d.bottleneck_distance(
+        empty, point, delta=0, compute_longest_edge=True
+    ) == (2, (-1, 0))
+
+
+def test_bottleneck_distance_uses_sentinel_edge_for_zero_and_infinity():
+    point = d.Diagram([(0, 4)])
+    essential_point = d.Diagram([(1, float("inf"))])
+    empty = d.Diagram([])
+
+    assert d.bottleneck_distance(
+        point, point, delta=0, compute_longest_edge=True
+    ) == (0, (-1, -1))
+
+    distance, edge = d.bottleneck_distance(
+        essential_point, empty, delta=0, compute_longest_edge=True
+    )
+    assert math.isinf(distance)
+    assert edge == (-1, -1)
+
+
+def test_bottleneck_distance_returns_longest_edge_in_approximate_mode():
+    dgm1 = d.Diagram([(0, 10)])
+    dgm2 = d.Diagram([(2, 12)])
+
+    distance, edge = d.bottleneck_distance(
+        dgm1, dgm2, delta=0.01, compute_longest_edge=True
+    )
+
+    assert 2 <= distance <= 2.02
+    assert edge == (0, 0)
+
+
+def test_bottleneck_distance_selects_edge_from_dominating_component():
+    for delta, essential_birth in ((0, 1.999), (0.01, 1.99)):
+        dgm1 = d.Diagram(
+            [(0, float("inf")), (0, 4)]
+        )
+        dgm2 = d.Diagram([(essential_birth, float("inf"))])
+
+        distance, edge = d.bottleneck_distance(
+            dgm1, dgm2, delta=delta, compute_longest_edge=True
+        )
+
+        assert distance == 2
+        assert edge == (1, -1)


### PR DESCRIPTION
Expose the edge realizing a bottleneck matching through an opt-in `compute_longest_edge` argument while preserving the existing scalar return value by default.

- return original diagram indices, using `-1` for diagonal endpoints
- define sentinels for zero and infinite distances
- preserve exact and approximate distance behavior
- add focused regression coverage and user documentation

Closes #25