### PR TITLE
Prevent Wasserstein auction stagnation

### DIFF
--- a/bindings/python/wasserstein-distance.cpp
+++ b/bindings/python/wasserstein-distance.cpp
@@ -5,14 +5,30 @@ namespace py = pybind11;
 
 #include <hera/wasserstein.h>
 
+class WassersteinDiagramView
+{
+    public:
+        using const_iterator = PyDiagram::const_iterator;
+
+        explicit WassersteinDiagramView(const PyDiagram& diagram):
+            diagram_(diagram)
+        {}
+
+        const_iterator begin() const      { return diagram_.begin(); }
+        const_iterator end() const        { return diagram_.end(); }
+
+    private:
+        const PyDiagram& diagram_;
+};
+
 namespace hera
 {
 template<>
-struct DiagramTraits<PyDiagram>
+struct DiagramTraits<WassersteinDiagramView>
 {
-    using Container = PyDiagram;
+    using Container = WassersteinDiagramView;
     using PointType = PyDiagram::Point;
-    using RealType  = PyDiagram::Value;
+    using RealType  = double;
 
     static RealType get_x(const PointType& p)       { return p[0]; }
     static RealType get_y(const PointType& p)       { return p[1]; }
@@ -20,9 +36,11 @@ struct DiagramTraits<PyDiagram>
 };
 }
 
+using WassersteinReal = hera::DiagramTraits<WassersteinDiagramView>::RealType;
+
 double wasserstein_distance(const PyDiagram& dgm1, const PyDiagram& dgm2, int q, double delta, double internal_p, double initial_eps, double eps_factor)
 {
-    hera::AuctionParams<PyDiagram::Value> params;
+    hera::AuctionParams<WassersteinReal> params;
     params.wasserstein_power = q;
     params.delta = delta;
     params.internal_p = internal_p;
@@ -33,7 +51,9 @@ double wasserstein_distance(const PyDiagram& dgm1, const PyDiagram& dgm2, int q,
     if (eps_factor != 0.)
         params.epsilon_common_ratio = eps_factor;
 
-    return hera::wasserstein_dist(dgm1, dgm2, params);
+    const WassersteinDiagramView view1(dgm1);
+    const WassersteinDiagramView view2(dgm2);
+    return hera::wasserstein_dist(view1, view2, params);
 }
 
 void init_wasserstein_distance(py::module& m)
@@ -41,7 +61,7 @@ void init_wasserstein_distance(py::module& m)
     using namespace pybind11::literals;
     m.def("wasserstein_distance",   &wasserstein_distance, "dgm1"_a, "dgm2"_a, py::arg("q") = 2,
                                                             py::arg("delta") = .01,
-                                                            py::arg("internal_p") = hera::get_infinity<PyDiagram::Value>(),
+                                                            py::arg("internal_p") = hera::get_infinity<WassersteinReal>(),
                                                             py::arg("initial_eps") = 0.,
                                                             py::arg("eps_factor") = 0.,
           "compute Wasserstein distance between two persistence diagrams");

--- a/tests/test_issue39.py
+++ b/tests/test_issue39.py
@@ -1,18 +1,31 @@
 from pathlib import Path
+import subprocess
+import sys
 
-import numpy as np
 import pytest
-import dionysus as d
-
-
-pytestmark = pytest.mark.skip(reason="issue39 wasserstein regression currently hangs")
 
 
 def test_issue39():
-    data_dir = Path(__file__).parent / 'data' / 'issue39'
-    dgm1 = np.loadtxt(data_dir / 'dgm1.txt', delimiter=',')
-    dgm2 = np.loadtxt(data_dir / 'dgm2.txt', delimiter=',')
-    dgm1 = d.Diagram(dgm1)
-    dgm2 = d.Diagram(dgm2)
-    dist = d.wasserstein_distance(dgm1,dgm2,q=5)
-    assert dist >= 0
+    data_dir = Path(__file__).parent / "data" / "issue39"
+    script = """
+import sys
+from pathlib import Path
+
+import dionysus as d
+import numpy as np
+
+data_dir = Path(sys.argv[1])
+dgm1 = d.Diagram(np.loadtxt(data_dir / "dgm1.txt", delimiter=","))
+dgm2 = d.Diagram(np.loadtxt(data_dir / "dgm2.txt", delimiter=","))
+print(d.wasserstein_distance(dgm1, dgm2, q=5))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(data_dir)],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    # Hera guarantees delta-relative accuracy; use the exact 1-D reference value.
+    assert float(result.stdout) == pytest.approx(0.009632668295414, rel=0.01)


### PR DESCRIPTION
## Summary

- promote Hera's Wasserstein arithmetic to double through a distinct non-owning diagram view
- preserve the public float-backed diagram API without copying inputs
- replace the skipped issue reproducer with a subprocess-bounded regression

The reported high-multiplicity input previously stalled because float price increments rounded to no progress inside Hera's unbounded auction phase. Double precision resolves the supplied case while retaining existing API defaults. As with any finite floating type, this does not claim universal termination for arbitrary cardinality and coordinate separation.

## Verification

- `uv run --group test pytest -q tests/test_issue39.py tests/test_distances.py` — 7 passed
- `uv run --group test pytest -q` — 107 passed, 1 skipped
- required reviewer approved the final corrected implementation with no findings

Closes #39